### PR TITLE
deploy: version 1.0.1 to UAT

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -12,9 +12,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.12.0</quarkus.platform.version>
+    <quarkus.platform.version>3.12.3</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.3.0</surefire-plugin.version>
+    <surefire-plugin.version>3.3.1</surefire-plugin.version>
     <jacoco.version>0.8.12</jacoco.version>
     <sonar.exclusions>**/Roles.kt,**/*Test.kt</sonar.exclusions>
     <sonar.cpd.exclusions>**/AuthResource.kt</sonar.cpd.exclusions>
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.mockito.kotlin</groupId>
       <artifactId>mockito-kotlin</artifactId>
-      <version>5.3.1</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -12,9 +12,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.12.0</quarkus.platform.version>
+    <quarkus.platform.version>3.12.3</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.3.0</surefire-plugin.version>
+    <surefire-plugin.version>3.3.1</surefire-plugin.version>
     <jacoco.version>0.8.12</jacoco.version>
   </properties>
   <dependencyManagement>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.mockito.kotlin</groupId>
       <artifactId>mockito-kotlin</artifactId>
-      <version>5.3.1</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tiny-img-service/pom.xml
+++ b/tiny-img-service/pom.xml
@@ -12,9 +12,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.12.0</quarkus.platform.version>
+    <quarkus.platform.version>3.12.3</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.3.0</surefire-plugin.version>
+    <surefire-plugin.version>3.3.1</surefire-plugin.version>
     <jacoco.version>0.8.12</jacoco.version>
     <sonar.exclusions>**/Roles.kt,**/*Test.kt,**/util/**</sonar.exclusions>
     <sonar.cpd.exclusions>**/ImageResource.kt</sonar.cpd.exclusions>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.mockito.kotlin</groupId>
       <artifactId>mockito-kotlin</artifactId>
-      <version>5.3.1</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
* build(deps): bump surefire-plugin.version in /auth-service (#52)

Bumps `surefire-plugin.version` from 3.3.0 to 3.3.1.

Updates `org.apache.maven.plugins:maven-surefire-plugin` from 3.3.0 to 3.3.1
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

Updates `org.apache.maven.plugins:maven-failsafe-plugin` from 3.3.0 to 3.3.1
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump quarkus.platform.version in /notification-service (#54)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.3.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.3
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.3)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.3
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.3)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump quarkus.platform.version in /auth-service (#55)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.3.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.3
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.3)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.3
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.3)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump quarkus.platform.version in /tiny-img-service (#53)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.3.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.3
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.3)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.3
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.3)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump surefire-plugin.version in /tiny-img-service (#49)

Bumps `surefire-plugin.version` from 3.3.0 to 3.3.1.

Updates `org.apache.maven.plugins:maven-surefire-plugin` from 3.3.0 to 3.3.1
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

Updates `org.apache.maven.plugins:maven-failsafe-plugin` from 3.3.0 to 3.3.1
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump surefire-plugin.version in /notification-service (#47)

Bumps `surefire-plugin.version` from 3.3.0 to 3.3.1.

Updates `org.apache.maven.plugins:maven-surefire-plugin` from 3.3.0 to 3.3.1
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

Updates `org.apache.maven.plugins:maven-failsafe-plugin` from 3.3.0 to 3.3.1
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps-dev): bump org.mockito.kotlin:mockito-kotlin in /auth-service (#46)

Bumps [org.mockito.kotlin:mockito-kotlin](https://github.com/mockito/mockito-kotlin) from 5.3.1 to 5.4.0.
- [Release notes](https://github.com/mockito/mockito-kotlin/releases)
- [Commits](https://github.com/mockito/mockito-kotlin/compare/5.3.1...5.4.0)

---
updated-dependencies:
- dependency-name: org.mockito.kotlin:mockito-kotlin dependency-type: direct:development update-type: version-update:semver-minor ...




* build(deps-dev): bump org.mockito.kotlin:mockito-kotlin (#45)

Bumps [org.mockito.kotlin:mockito-kotlin](https://github.com/mockito/mockito-kotlin) from 5.3.1 to 5.4.0.
- [Release notes](https://github.com/mockito/mockito-kotlin/releases)
- [Commits](https://github.com/mockito/mockito-kotlin/compare/5.3.1...5.4.0)

---
updated-dependencies:
- dependency-name: org.mockito.kotlin:mockito-kotlin dependency-type: direct:development update-type: version-update:semver-minor ...




* build(deps-dev): bump org.mockito.kotlin:mockito-kotlin (#44)

Bumps [org.mockito.kotlin:mockito-kotlin](https://github.com/mockito/mockito-kotlin) from 5.3.1 to 5.4.0.
- [Release notes](https://github.com/mockito/mockito-kotlin/releases)
- [Commits](https://github.com/mockito/mockito-kotlin/compare/5.3.1...5.4.0)

---
updated-dependencies:
- dependency-name: org.mockito.kotlin:mockito-kotlin dependency-type: direct:development update-type: version-update:semver-minor ...




* build(deps): bump quarkus.platform.version in /tiny-img-service (#41)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.1.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.1)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.1)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...





* build(deps): bump quarkus.platform.version in /auth-service (#42)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.1.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.1)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.1)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...





* build(deps): bump quarkus.platform.version in /notification-service (#48)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.2.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.2
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.2)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.2
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.2)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...





* build(deps): bump quarkus.platform.version in /tiny-img-service (#50)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.2.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.2
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.2)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.2
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.2)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...





* build(deps): bump quarkus.platform.version in /auth-service (#51)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.2.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.2
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.2)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.2
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.2)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...





* build(deps): bump quarkus.platform.version in /notification-service (#43)

Bumps `quarkus.platform.version` from 3.12.0 to 3.12.1.

Updates `io.quarkus.platform:quarkus-bom` from 3.12.0 to 3.12.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.1)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.12.0 to 3.12.1
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.12.0...3.12.1)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...





---------